### PR TITLE
Enable lwip PPPoS server listen support

### DIFF
--- a/components/lwip/api/pppapi.c
+++ b/components/lwip/api/pppapi.c
@@ -270,11 +270,12 @@ pppapi_connect(ppp_pcb *pcb, u16_t holdoff)
 /**
  * Call ppp_listen() inside the tcpip_thread context.
  */
-static void
-pppapi_do_ppp_listen(struct pppapi_msg_msg *msg)
+static err_t
+pppapi_do_ppp_listen(struct tcpip_api_call *m)
 {
-  msg->err = ppp_listen(msg->ppp, msg->msg.listen.addrs);
-  TCPIP_PPPAPI_ACK(msg);
+  struct pppapi_msg *msg = (struct pppapi_msg *)m;
+    
+  return ppp_listen(msg->msg.ppp, msg->msg.msg.listen.addrs);
 }
 
 /**
@@ -285,11 +286,10 @@ err_t
 pppapi_listen(ppp_pcb *pcb, struct ppp_addrs *addrs)
 {
   struct pppapi_msg msg;
-  msg.function = pppapi_do_ppp_listen;
   msg.msg.ppp = pcb;
   msg.msg.msg.listen.addrs = addrs;
-  TCPIP_PPPAPI(&msg);
-  return msg.msg.err;
+
+  return tcpip_api_call(pppapi_do_ppp_listen, &msg.call);
 }
 #endif /* PPP_SERVER */
 


### PR DESCRIPTION
Modified pppapi_listen and pppapi_do_ppp_listen to be consistent with ppp_connect. They no longer use: undefined TCPIP_PPPAPI macro; msg,function which is not a member of pppapi_msg structure; msg.err, which is not a member of pppapi_msg_msg structure. 
ESP32 lwip will now compile and run as PPP server with PPP_SERVER defined.